### PR TITLE
Fix paging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstroke/server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "src/server.js",
   "dependencies": {

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -8,7 +8,7 @@ export const PAGE_SIZE = 20;
 // Model.all({...paginate(req)}).then(data => ...);
 export function paginate(req) {
   let page = parseInt(req.query.page, 10) || 0;
-  return {skip: page * PAGE_SIZE, limit: PAGE_SIZE};
+  return {offset: page * PAGE_SIZE, limit: PAGE_SIZE};
 }
 
 // Something bad happened. Throw a 500.

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -7,7 +7,7 @@ export const PAGE_SIZE = 20;
 // Use like:
 // Model.all({...paginate(req)}).then(data => ...);
 export function paginate(req) {
-  let page = req.query.page || 0;
+  let page = parseInt(req.query.page, 10) || 0;
   return {skip: page * PAGE_SIZE, limit: PAGE_SIZE};
 }
 

--- a/src/routes/links/list/index.js
+++ b/src/routes/links/list/index.js
@@ -12,7 +12,6 @@ export default function index(req, res, Link) {
       return {
         page: req.query.page || 0,
         data,
-        lastItem: paginate(req).skip + data.length,
       };
     });
   });

--- a/src/routes/links/list/index.js
+++ b/src/routes/links/list/index.js
@@ -3,7 +3,7 @@ import {PAGE_SIZE, paginate} from '../../helpers';
 // Return a list of all links that belong to the logged in user.
 // This route is paginated.
 export default function index(req, res, Link) {
-  return Link.all({
+  return Link.findAll({
     where: {ownerId: req.user.id},
     ...paginate(req),
   }).then(data => {

--- a/src/routes/links/list/index.js
+++ b/src/routes/links/list/index.js
@@ -10,7 +10,8 @@ export default function index(req, res, Link) {
     // Add all owners to each link
     return Promise.all(data.map(i => i.display())).then(data => {
       return {
-        page: req.query.page || 0,
+        page: parseInt(req.query.page, 10) || 0,
+        pageSize: PAGE_SIZE,
         data,
       };
     });

--- a/src/routes/links/list/test.js
+++ b/src/routes/links/list/test.js
@@ -43,6 +43,7 @@ describe('link list', () => {
       const body = res.body;
       assert.equal(body.data.length, 1);
       assert.equal(body.data[0].id, linkData.id);
+      assert.equal(body.page, 0);
     });
   });
 
@@ -67,6 +68,7 @@ describe('link list', () => {
       ).then(res => {
         const body = res.body;
         assert.equal(body.data.length, 20);
+        assert.equal(body.page, 0);
       });
     });
     it('should return the second, partial page of all links for a user', () => {
@@ -81,6 +83,7 @@ describe('link list', () => {
       ).then(res => {
         const body = res.body;
         assert.equal(body.data.length, 5);
+        assert.equal(body.page, 1);
       });
     });
     it('should return the third, empty page of all links for a user', () => {
@@ -95,6 +98,7 @@ describe('link list', () => {
       ).then(res => {
         const body = res.body;
         assert.equal(body.data.length, 0);
+        assert.equal(body.page, 2);
       });
     });
   });

--- a/src/routes/links/list/test.js
+++ b/src/routes/links/list/test.js
@@ -24,6 +24,7 @@ describe('link list', () => {
       return Link.create({
         name: 'My Link',
         enabled: true,
+        owner: userData.id,
       });
     }).then(link => {
       linkData = link;
@@ -42,6 +43,59 @@ describe('link list', () => {
       const body = res.body;
       assert.equal(body.data.length, 1);
       assert.equal(body.data[0].id, linkData.id);
+    });
+  });
+
+  describe('paging', () => {
+    beforeEach(() => {
+      // Add 25 links to the model.
+      Link.models = [];
+      for (let i = 0; i < 25; i++) {
+        Link.models.push({id: i, name: `My link: ${Math.random()}`, ownerId: userData.id});
+      }
+    });
+
+    it('should return the first, full page of all links for a user', () => {
+      return issueRequest(
+        list, [Link],
+        '/', userData, {
+          method: 'GET',
+          url: '/',
+          json: true,
+          qs: { page: '0' },
+        }
+      ).then(res => {
+        const body = res.body;
+        assert.equal(body.data.length, 20);
+      });
+    });
+    it('should return the second, partial page of all links for a user', () => {
+      return issueRequest(
+        list, [Link],
+        '/', userData, {
+          method: 'GET',
+          url: '/',
+          json: true,
+          qs: { page: '1' },
+        }
+      ).then(res => {
+        const body = res.body;
+        assert.equal(body.data.length, 5);
+      });
+    });
+    it('should return the third, empty page of all links for a user', () => {
+      return issueRequest(
+        list, [Link],
+        '/', userData, {
+          method: 'GET',
+          url: '/',
+          json: true,
+          qs: { page: '2' },
+        }
+      ).then(res => {
+        const body = res.body;
+        assert.equal(body.data.length, 0);
+      });
     });
   });
 });

--- a/src/test-helpers/mock-model.js
+++ b/src/test-helpers/mock-model.js
@@ -4,7 +4,6 @@ import Promise from 'bluebird';
 // in place of the real model.
 export default class MockModel {
   constructor(models, foreignKeyNames={}) {
-
     // A list of all models that exist.
     this.models = []
     if (models) {
@@ -16,7 +15,7 @@ export default class MockModel {
     this.methods = [];
   }
 
-  _handleQueries({where, limit, include}) {
+  _handleQueries({where, limit, include, offset}) {
     let models = this.models;
 
     if (where) {
@@ -28,6 +27,10 @@ export default class MockModel {
         }
         return true;
       });
+    }
+
+    if (offset) {
+      models = models.slice(offset)
     }
 
     if (limit) {
@@ -47,7 +50,6 @@ export default class MockModel {
         });
       });
     }
-
     return models;
   }
 
@@ -56,8 +58,8 @@ export default class MockModel {
     return Promise.resolve(model.length ? this.formatModelInstance(model[0]) : null);
   }
   findAll(query) {
-    const models = this._handleQueries({...query, limit: 1});
-    return Promise.resolve(models.length ? Promise.all(models.map(this.formatModelInstance)) : null);
+    const models = this._handleQueries(query);
+    return Promise.all(models.map(this.formatModelInstance.bind(this)));
   }
   update(data, query) {
     // Get models to update


### PR DESCRIPTION
Paging was broken when we migrated to sequelize, but it turns out that nothing used it so it wasn't noticed. I'm working on fixing that before https://github.com/backstrokeapp/dashboard/issues/4 is attempted.

Example response:
```json
{
  "page": 3,
  "data": [
    {
      "id": 248,
      "name": "My fork of nicss",
      "enabled": true,
      "webhook": "59305a11edee18001c240d58",
      "createdAt": "2017-10-07T19:01:21.914Z",
      "lastSyncedAt": "2017-10-08T19:07:36.304Z",
      "fork": {
        "type": "repo",
        "owner": "1egoman",
        "repo": "nicss",
        "isFork": true,
        "branches": [
          "contributing-doc",
          "master",
          "npm-publish-on-push"
        ],
        "branch": "master"
      },
      "upstream": {
        "type": "repo",
        "owner": "densityco",
        "repo": "nicss",
        "branches": [
          "contributing-doc",
          "master",
          "npm-publish-on-push"
        ],
        "branch": "master"
      }
    },
    (other links here...)
  ]
}
```